### PR TITLE
Django 1.8 support via nose -> pytest switch

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+omit =
+    */tests/*

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+DJANGO_SETTINGS_MODULE=test_settings

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,4 @@
 [pytest]
 DJANGO_SETTINGS_MODULE=test_settings
+addopts = --cov yet_another_django_profiler
+norecursedirs = .* docs requirements ve

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -2,20 +2,35 @@
 
 # Indirect dependencies first, exact versions for consistency
 
-# django-nose
-nose==1.3.4
+# pytest-cov -> cov-core
+coverage==3.7.1
+
+# pytest-cov -> pytest, tox
+py==1.4.26
+
+# pytest-cov
+cov-core==1.15.0
+pytest==2.7.0
+
+# pytest-xdist
+execnet==1.3.0
 
 # tox
-py==1.4.26
 virtualenv==12.0.5  # tox
 
 # And now the direct dependencies
 
-# For code coverage statistics generation
-coverage==3.7.1
+# Show log output for test failures
+pytest-capturelog==0.7
 
-# Our testing framework
-django-nose==1.3
+# For code coverage statistics generation
+pytest-cov==1.8.1
+
+# Django integration for test runner
+pytest-django==2.8.0
+
+# Parallel test execution support
+pytest-xdist==1.11
 
 # For managing test environments
 tox==1.8.1

--- a/test_settings.py
+++ b/test_settings.py
@@ -33,7 +33,6 @@ INSTALLED_APPS = (
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'yet_another_django_profiler',
-    'django_nose',
 )
 
 MIDDLEWARE_CLASSES = (
@@ -59,4 +58,3 @@ TIME_ZONE = 'UTC'
 USE_L10N = True
 USE_TZ = True
 STATIC_URL = '/static/'
-TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ deps =
     pytest-xdist==1.11
 commands =
     python setup.py --quiet develop --always-unzip
-    py.test --cov yet_another_django_profiler {posargs:yet_another_django_profiler}
+    py.test {posargs}
 
 [testenv:docs]
 changedir = {toxinidir}/docs

--- a/tox.ini
+++ b/tox.ini
@@ -1,25 +1,31 @@
 [tox]
-envlist = py27-django{15,16,17}
+envlist = py27-django{15,16,17,18}
 
 [testenv]
 setenv =
     DJANGO_SETTINGS_MODULE=test_settings
 deps =
     django15: Django==1.5.12
-    django16: Django==1.6.10
-    django17: Django==1.7.4
+    django16: Django==1.6.11
+    django17: Django==1.7.7
+    django18: Django==1.8
     coverage==3.7.1
     mock==1.0.1
-    nose==1.3.4
-    django-nose==1.3
+    py==1.4.26
+    cov-core==1.15.0
+    pytest==2.7.0
+    execnet==1.3.0
+    pytest-cov==1.8.1
+    pytest-django==2.8.0
+    pytest-xdist==1.11
 commands =
-    {envbindir}/python setup.py --quiet develop --always-unzip
-    {envbindir}/python {envbindir}/django-admin.py test {posargs} --noinput
+    python setup.py --quiet develop --always-unzip
+    py.test --cov yet_another_django_profiler {posargs:yet_another_django_profiler}
 
 [testenv:docs]
 changedir = {toxinidir}/docs
 deps =
-    Django==1.7.4
+    Django==1.8
     mock==1.0.1
 commands =
     pip install --disable-pip-version-check --requirement ../requirements/documentation.txt
@@ -28,11 +34,11 @@ commands =
 
 [testenv:flake8]
 deps =
-    Django==1.7.4
+    Django==1.8
     mccabe==0.3
-    pep8==1.6.1
+    pep8==1.5.7
     pyflakes==0.8.1
-    flake8==2.3.0
+    flake8==2.4.0
     mock==1.0.1
 commands =
     flake8 --ignore=E501 {posargs:yet_another_django_profiler setup.py test_settings.py test_urls.py}

--- a/yet_another_django_profiler/tests/test_parameters.py
+++ b/yet_another_django_profiler/tests/test_parameters.py
@@ -23,7 +23,7 @@ class ParametersTest(TestCase):
     def test_call_graph(self):
         """Using "profile" without a parameter should yield a PDF call graph"""
         response = self._get_test_page('profile')
-        self.assertEqual(response['Content-Type'], 'application/pdf')
+        assert response['Content-Type'] == 'application/pdf'
 
     def test_calls_by_count(self):
         """Using profile=calls should show a table of function calls sorted by call count"""


### PR DESCRIPTION
It looks like django-nose doesn't support Django 1.8 yet.  This change also enables parallel testing support (not that it helps that much with the current small number of test cases).