### PR TITLE
Fix profiling of admin pages (#15)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,6 @@ env:
   - TOX_ENV=pypy-django17
   - TOX_ENV=pypy-django18
   - TOX_ENV=pypy-django19
-  - TOX_ENV=pypy3-django15
-  - TOX_ENV=pypy3-django16
-  - TOX_ENV=pypy3-django17
-  - TOX_ENV=pypy3-django18
   - TOX_ENV=docs
   - TOX_ENV=flake8
 install:

--- a/requirements/analyze.txt
+++ b/requirements/analyze.txt
@@ -3,10 +3,10 @@
 # Indirect dependencies first, exact versions for consistency
 
 # flake8
-mccabe==0.3.1
-pep8==1.6.2
+mccabe==0.4.0
+pep8==1.7.0
 pyflakes==1.0.0
 
 # And now the direct dependencies
 
-flake8==2.5.0
+flake8==2.5.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,8 +1,8 @@
 # Core dependencies
 
 # Python packaging utilities
-setuptools==18.7.1
-pip==7.1.2
+setuptools==19.6
+pip==8.0.2
 
 # Indirect dependencies first, exact versions for consistency
 
@@ -13,7 +13,7 @@ pbr==1.8.1; python_version < '3.3'
 # And now the direct dependencies
 
 # The framework we're profiling
-Django==1.9
+Django==1.9.1
 
 # Used to override pstats function path stripping behavior
 mock==1.3.0; python_version < '3.3'

--- a/requirements/documentation.txt
+++ b/requirements/documentation.txt
@@ -2,21 +2,24 @@
 
 # Indirect dependencies to pin for consistency
 
-# readme -> bleach -> html5lib, Sphinx
+# readme_renderer -> bleach -> html5lib, Sphinx
 six==1.10.0
 
-# readme -> bleach
+# readme_renderer -> bleach
 html5lib==0.9999999
 
-# readme
+# readme_renderer
 bleach==1.4.2
 
-# readme, Sphinx
+# readme_renderer, Sphinx
 docutils==0.12
-Pygments==2.0.2
+Pygments==2.1
 
 # Sphinx -> Babel
 pytz==2015.7
+
+# sbo-sphinx -> recommonmark
+CommonMark==0.5.4
 
 # sbo-sphinx -> Sphinx -> Jinja2
 MarkupSafe==0.23
@@ -25,21 +28,22 @@ MarkupSafe==0.23
 PyStemmer==1.3.0
 
 # sbo-sphinx-> Sphinx
-Babel==2.1.1
+Babel==2.2.0
 Jinja2==2.8
-snowballstemmer==1.2.0
+snowballstemmer==1.2.1
 
 # sbo-sphinx
-Sphinx==1.3.3
+recommonmark==0.4.0
+Sphinx==1.3.5
 
 # Sphinx themes (circular dependencies of Sphinx)
-alabaster==0.7.6
+alabaster==0.7.7
 sphinx_rtd_theme==0.1.9
 
 # Direct dependencies
 
 # The README parser used by PyPI, used to validate README.rst
-readme==0.6.0
+readme_renderer==0.7.0
 
 # Utilities for managing technical documentation
 sbo-sphinx==2.2.0

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -6,19 +6,19 @@
 path.py==8.1.2; platform_python_implementation != 'PyPy'
 
 # ipdb -> ipython -> traitlets
-decorator==4.0.4; platform_python_implementation != 'PyPy'
+decorator==4.0.6; platform_python_implementation != 'PyPy'
 ipython-genutils==0.1.0; platform_python_implementation != 'PyPy'
 
 # ipdb -> ipython
 appnope==0.1.0; sys_platform == 'darwin' and platform_python_implementation != 'PyPy'
 gnureadline==6.3.3; sys_platform == 'darwin' and platform_python_implementation != 'PyPy'
 pexpect==3.3; sys_platform != 'win32' and platform_python_implementation != 'PyPy'
-pickleshare==0.5; platform_python_implementation != 'PyPy'
+pickleshare==0.6; platform_python_implementation != 'PyPy'
 simplegeneric==0.8.1; platform_python_implementation != 'PyPy'
-traitlets==4.0.0; platform_python_implementation != 'PyPy'
+traitlets==4.1.0; platform_python_implementation != 'PyPy'
 
 # ipdb
-ipython==4.0.1; platform_python_implementation != 'PyPy'
+ipython==4.0.3; platform_python_implementation != 'PyPy'
 
 # pytest-cov -> cov-core
 coverage==4.0.3
@@ -28,7 +28,7 @@ py==1.4.31
 
 # pytest-cov
 cov-core==1.15.0
-pytest==2.8.4
+pytest==2.8.7
 
 # pytest-xdist
 execnet==1.4.1
@@ -39,7 +39,7 @@ execnet==1.4.1
 ipdb==0.8.1; platform_python_implementation != 'PyPy'
 
 # Show log output for test failures
-pytest-catchlog==1.2.0
+pytest-catchlog==1.2.2
 
 # For code coverage statistics generation
 pytest-cov==2.2.0

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -9,11 +9,11 @@ greenlet==0.4.9
 # detox -> tox
 pluggy==0.3.1
 py==1.4.31
-virtualenv==13.1.2
+virtualenv==14.0.1
 
 # detox
-eventlet==0.17.4
-tox==2.2.1
+eventlet==0.18.1
+tox==2.3.1
 
 # And now the direct dependencies
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ yet-another-django-profiler setup script
 """
 
 import codecs
-import os
 import sys
 from setuptools import find_packages, setup
 
@@ -23,18 +22,6 @@ install_requires = [
 
 if '{0.major}.{0.minor}'.format(sys.version_info) < '3.3':
     install_requires.append('mock')
-
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-if on_rtd:
-    from pip.download import PipSession
-    from pip.index import PackageFinder
-    from pip.req import parse_requirements
-    session = PipSession()
-    root_dir = os.path.abspath(os.path.dirname(__file__))
-    requirements_path = os.path.join(root_dir, 'requirements', 'documentation.txt')
-    finder = PackageFinder([], [], session=session)
-    requirements = parse_requirements(requirements_path, finder, session=session)
-    install_requires.extend([str(r.req) for r in requirements])
 
 with codecs.open('README.rst', 'r', 'utf-8') as f:
     long_description = f.read()

--- a/test_settings.py
+++ b/test_settings.py
@@ -47,6 +47,25 @@ MIDDLEWARE_CLASSES = (
 
 ROOT_URLCONF = 'test_urls'
 
+TEMPLATE_CONTEXT_PROCESSORS = (
+    'django.contrib.auth.context_processors.auth',
+    'django.core.context_processors.i18n',
+    'django.contrib.messages.context_processors.messages',
+)
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ]
+        }
+    },
+]
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',

--- a/test_urls.py
+++ b/test_urls.py
@@ -8,7 +8,9 @@
 URL configuration for Yet Another Django Profiler tests.
 """
 
-from django.conf.urls import patterns, url
+import django
+from django.conf.urls import include, url
+from django.contrib import admin
 from django.http import HttpResponse
 from django.views.generic.base import View
 
@@ -18,7 +20,10 @@ class TestView(View):
     def get(self, request, *args, **kwargs):
         return HttpResponse('This is only a test.')
 
-urlpatterns = patterns(
-    '',
+if django.VERSION[0] == 1 and django.VERSION[1] < 7:
+    admin.autodiscover()
+
+urlpatterns = [
     url(r'^test/', TestView.as_view(), name='test'),
-)
+    url(r'^admin/', include(admin.site.urls)),
+]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,33,34,py,py3}-django{15,16,17,18},py{27,34,py}-django19,py35-django{18,19}
+envlist = py{27,33,34,py}-django{15,16,17,18},py{27,34,py}-django19,py35-django{18,19}
 
 [pytest]
 addopts = --cov yet_another_django_profiler --cov-report term-missing
@@ -11,8 +11,8 @@ deps =
     django15: Django==1.5.12
     django16: Django==1.6.11
     django17: Django==1.7.11
-    django18: Django==1.8.7
-    django19: Django==1.9
+    django18: Django==1.8.8
+    django19: Django==1.9.1
     py{27,32,py}: funcsigs==0.4
     py{27,32,py}: pbr==1.8.1
     py{27,32,py}: mock==1.3.0

--- a/yet_another_django_profiler/tests/test_admin.py
+++ b/yet_another_django_profiler/tests/test_admin.py
@@ -1,0 +1,77 @@
+# encoding: utf-8
+# Created by Jeremy Bowman on Fri Feb 21 17:28:37 EST 2014
+# Copyright (c) 2014, 2015 Safari Books Online. All rights reserved.
+#
+# This software may be modified and distributed under the terms
+# of the 3-clause BSD license.  See the LICENSE file for details.
+"""
+Yet Another Django Profiler Django admin profiling tests
+"""
+
+from __future__ import unicode_literals
+
+import platform
+import sys
+
+from django.contrib.auth.models import User
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+from django.test.utils import override_settings
+from django.utils.text import force_text
+
+import pytest
+
+
+class AdminCases(object):
+    """Django admin page profiling tests to be run for each profiler backend"""
+
+    def test_call_graph(self):
+        """Using "profile" without a parameter should yield a PDF call graph even for admin changelists"""
+        response = self._get_test_page('profile')
+        assert response['Content-Type'] == 'application/pdf'
+
+    def test_calls_by_time(self):
+        """Using profile=time should show a table of function calls sorted by internal time even for admin changelists"""
+        response = self._get_test_page('profile=time')
+        self.assertContains(response, 'Ordered by: internal time')
+
+    def test_pattern(self):
+        """It should be possible to specify a regular expression filter pattern even for admin changelists"""
+        response = self._get_test_page('profile=time&pattern=models')
+        self.assertRegexpMatches(force_text(response.content, 'utf-8'), r"due to restriction <u?'models'>")
+
+    def _get_test_page(self, params=''):
+        url = reverse('admin:auth_user_changelist')
+        if params:
+            url += '?' + params
+        return self.client.get(url)
+
+
+@override_settings(YADP_ENABLED=True)
+class CProfileTest(TestCase, AdminCases):
+    """Profiling parameter tests using cProfile"""
+
+    def setUp(self):
+        User.objects.create_superuser('admin', 'admin@example.com', 'password')
+        self.client.login(username='admin', password='password')
+
+    def test_backend(self):
+        """The cProfile profiling backend should be used"""
+        from yet_another_django_profiler.conf import settings
+        assert settings.YADP_PROFILER_BACKEND == 'cProfile'
+
+
+@pytest.mark.skipif(platform.python_implementation() != 'CPython' or sys.version_info[:2] in ((3, 2), (3, 5)),
+                    reason='yappi does not yet work in this Python implementation')
+@override_settings(YADP_ENABLED=True, YADP_PROFILER_BACKEND='yappi')
+class YappiTest(TestCase, AdminCases):
+    """Profiling parameter tests using Yappi instead of cProfile"""
+
+    def setUp(self):
+        User.objects.create_superuser('admin', 'admin@example.com', 'password')
+        self.client.login(username='admin', password='password')
+
+    def test_backend(self):
+        """The Yappi profiling backend should be used"""
+        from yet_another_django_profiler.conf import settings
+        assert settings.YADP_PROFILER_BACKEND == 'yappi'


### PR DESCRIPTION
Fix profiling of Django admin pages by removing the profiling parameters before passing the request along to the actual view.  Also updated some dependencies, and temporarily removed testing of pypy3 because the current release of setuptools has a bug which breaks it in that environment.  (Should be able to add that back once the next setuptools version is released, the fix is already in master.)