### PR TITLE
Preserve PYTHONPATH in gprof2dot process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ env:
   - TOX_ENV=pypy3-django17
   - TOX_ENV=pypy3-django18
   - TOX_ENV=docs
-  - TOX_ENV=flake8
+  - TOX_ENV=analyze
 install:
   - pip install tox==2.1.1
   - pip install coveralls==1.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,10 @@ env:
   - TOX_ENV=pypy-django17
   - TOX_ENV=pypy-django18
   - TOX_ENV=pypy-django19
+  - TOX_ENV=pypy3-django15
+  - TOX_ENV=pypy3-django16
+  - TOX_ENV=pypy3-django17
+  - TOX_ENV=pypy3-django18
   - TOX_ENV=docs
   - TOX_ENV=flake8
 install:

--- a/requirements/analyze.txt
+++ b/requirements/analyze.txt
@@ -9,4 +9,4 @@ pyflakes==1.0.0
 
 # And now the direct dependencies
 
-flake8==2.5.1
+flake8==2.5.2

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 # Core dependencies
 
 # Python packaging utilities
-setuptools==19.6
+setuptools==19.6.1
 pip==8.0.2
 
 # Indirect dependencies first, exact versions for consistency

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 # Core dependencies
 
 # Python packaging utilities
-setuptools==19.6.1
+setuptools==19.6.2
 pip==8.0.2
 
 # Indirect dependencies first, exact versions for consistency

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -42,13 +42,13 @@ ipdb==0.8.1; platform_python_implementation != 'PyPy'
 pytest-catchlog==1.2.2
 
 # For code coverage statistics generation
-pytest-cov==2.2.0
+pytest-cov==2.2.1
 
 # Django integration for test runner
 pytest-django==2.9.1
 
 # Parallel test execution support
-pytest-xdist==1.13.1
+pytest-xdist==1.14
 
 # For testing the Yappi profiler backend
 yappi==0.94; platform_python_implementation == 'CPython' and (python_version == '2.7' or (python_version > '3.2' and python_version < '3.5'))

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -9,7 +9,7 @@ greenlet==0.4.9
 # detox -> tox
 pluggy==0.3.1
 py==1.4.31
-virtualenv==14.0.1
+virtualenv==14.0.3
 
 # detox
 eventlet==0.18.1

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -9,7 +9,7 @@ greenlet==0.4.9
 # detox -> tox
 pluggy==0.3.1
 py==1.4.31
-virtualenv==14.0.3
+virtualenv==14.0.5
 
 # detox
 eventlet==0.18.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,33,34,py}-django{15,16,17,18},py{27,34,py}-django19,py35-django{18,19}
+envlist = py{27,33,34,py,py3}-django{15,16,17,18},py{27,34,py}-django19,py35-django{18,19}
 
 [pytest]
 addopts = --cov yet_another_django_profiler --cov-report term-missing

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ commands =
     sphinx-build -b {posargs:html} docs docs/_build
     python setup.py check --restructuredtext --strict
 
-[testenv:flake8]
+[testenv:analyze]
 deps = -r{toxinidir}/requirements/base.txt
 commands =
     pip install --quiet --requirement requirements/analyze.txt

--- a/yet_another_django_profiler/management/commands/profile.py
+++ b/yet_another_django_profiler/management/commands/profile.py
@@ -14,6 +14,7 @@ import atexit
 import cProfile
 import marshal
 from optparse import make_option
+import os
 import pstats
 import subprocess
 import sys
@@ -135,8 +136,12 @@ def output_results(profiler, options, stdout):
             stats.write(marshal.dumps(profiler.stats))
             stats.flush()
             cmd = ('gprof2dot.py -f pstats {} | dot -Tpdf'.format(stats.name))
+            # Get a copy of the existing environment.
+            env = os.environ.copy()
+            # Add the PYTHONPATH using the existing python system path.
+            env['PYTHONPATH'] = os.pathsep.join(sys.path)
             process = subprocess.Popen(cmd, shell=True, stdin=subprocess.PIPE,
-                                       stdout=subprocess.PIPE)
+                                       stdout=subprocess.PIPE, env=env)
             output = process.communicate()[0]
             return_code = process.poll()
             if return_code:

--- a/yet_another_django_profiler/middleware.py
+++ b/yet_another_django_profiler/middleware.py
@@ -16,6 +16,7 @@ import marshal
 import os
 import pstats
 import subprocess
+import sys
 import tempfile
 
 try:
@@ -182,8 +183,12 @@ class ProfilerMiddleware(object):
                     stats.write(marshal.dumps(self.profiler.stats))
                     stats.flush()
                     cmd = ('gprof2dot.py -f pstats {} | dot -Tpdf'.format(stats.name))
+                    # Get a copy of the existing environment.
+                    env = os.environ.copy()
+                    # Add the PYTHONPATH using the existing python system path.
+                    env['PYTHONPATH'] = os.pathsep.join(sys.path)
                     process = subprocess.Popen(cmd, shell=True, stdin=subprocess.PIPE,
-                                               stdout=subprocess.PIPE)
+                                               stdout=subprocess.PIPE, env=env)
                     output = process.communicate()[0]
                     return_code = process.poll()
                     if return_code:

--- a/yet_another_django_profiler/utils.py
+++ b/yet_another_django_profiler/utils.py
@@ -1,0 +1,35 @@
+# encoding: utf-8
+# Created by Jeremy Bowman on Mon Feb  1 12:48:09 EST 2016
+# Copyright (c) 2016 Safari Books Online. All rights reserved.
+#
+# This software may be modified and distributed under the terms
+# of the 3-clause BSD license.  See the LICENSE file for details.
+"""
+Utility functions for Yet Another Django Profiler
+"""
+
+import marshal
+import os
+import subprocess
+import sys
+import tempfile
+
+
+def run_gprof2dot(profiler):
+    """Run gprof2dot.py on the data from the provided profiler to generate a
+    call graph in PDF format.
+
+    :param profiler The profiler containing the data to be graphed
+    :return A tuple of the subprocess return code and its stdout (the PDF data)
+    """
+    with tempfile.NamedTemporaryFile() as stats:
+        stats.write(marshal.dumps(profiler.stats))
+        stats.flush()
+        cmd = ('gprof2dot.py -f pstats {} | dot -Tpdf'.format(stats.name))
+        env = os.environ.copy()
+        env['PYTHONPATH'] = os.pathsep.join(sys.path)
+        process = subprocess.Popen(cmd, shell=True, stdin=subprocess.PIPE,
+                                   stdout=subprocess.PIPE, env=env)
+        output = process.communicate()[0]
+        return_code = process.poll()
+    return return_code, output


### PR DESCRIPTION
As noted in #16, there are some potential problems loading settings from the subprocess used to run gprof2dot.py.  The PYTHONPATH is actually passed along to it, but any relative paths in it will fail to resolve because the working directory is different.  It isn't a problem if your settings are in a module which has been installed into the environment, but doesn't work if you were just counting on relative path resolution to find the settings module.  This change explicitly sets the PYTHONPATH using the absolute paths in the parent process's ``sys.path`` (for both the middleware and management command).

Also restored PyPy 3 testing, now that setuptools 19.6.1 has been released.