### PR TITLE
Support for StreamingHttpResponse (#17)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,4 @@
 [run]
+branch = true
 omit =
     */tests/*

--- a/README.rst
+++ b/README.rst
@@ -99,6 +99,10 @@ sub-strings unless you really enjoy figuring out how to URL-escape special
 characters.) By default when using yappi it will use `cpu` clock type if
 what you want is `wall` time you can use ``clock=wall``.
 
+Views which return a StreamingHttpResponse can be profiled, but the profiling
+data stops at the return of the response from the view; the iteration over the
+content isn't profiled.
+
 If you forget the available sorting options and such, you can use
 ``profile=help`` as a request parameter to display the usage instructions in
 the browser.

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 # Core dependencies
 
 # Python packaging utilities
-setuptools==19.6.2
+setuptools==19.7
 pip==8.0.2
 
 # Indirect dependencies first, exact versions for consistency
@@ -13,7 +13,7 @@ pbr==1.8.1; python_version < '3.3'
 # And now the direct dependencies
 
 # The framework we're profiling
-Django==1.9.1
+Django==1.9.2
 
 # Used to override pstats function path stripping behavior
 mock==1.3.0; python_version < '3.3'

--- a/test_urls.py
+++ b/test_urls.py
@@ -11,7 +11,7 @@ URL configuration for Yet Another Django Profiler tests.
 import django
 from django.conf.urls import include, url
 from django.contrib import admin
-from django.http import HttpResponse
+from django.http import HttpResponse, StreamingHttpResponse
 from django.views.generic.base import View
 
 
@@ -20,10 +20,17 @@ class TestView(View):
     def get(self, request, *args, **kwargs):
         return HttpResponse('This is only a test.')
 
+
+class StreamingView(View):
+
+    def get(self, request, *args, **kwargs):
+        return StreamingHttpResponse(('Line {}\n'.format(i + 1) for i in range(100)))
+
 if django.VERSION[0] == 1 and django.VERSION[1] < 7:
     admin.autodiscover()
 
 urlpatterns = [
-    url(r'^test/', TestView.as_view(), name='test'),
+    url(r'^test/$', TestView.as_view(), name='test'),
+    url(r'^test/streaming/$', StreamingView.as_view(), name='test_streaming'),
     url(r'^admin/', include(admin.site.urls)),
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,8 @@ deps =
     django15: Django==1.5.12
     django16: Django==1.6.11
     django17: Django==1.7.11
-    django18: Django==1.8.8
-    django19: Django==1.9.1
+    django18: Django==1.8.9
+    django19: Django==1.9.2
     py{27,32,py}: funcsigs==0.4
     py{27,32,py}: pbr==1.8.1
     py{27,32,py}: mock==1.3.0

--- a/yet_another_django_profiler/tests/test_parameters.py
+++ b/yet_another_django_profiler/tests/test_parameters.py
@@ -111,6 +111,22 @@ class ParameterCases(object):
         response = self._get_test_page('profile=time&pattern=test')
         self.assertRegexpMatches(force_text(response.content, 'utf-8'), r"due to restriction <u?'test'>")
 
+    def test_streaming_call_graph(self):
+        """It should be possible to get a PDF call graph for a view which returns a StreamingHttpResponse"""
+        response = self._get_streaming_page('profile')
+        assert response['Content-Type'] == 'application/pdf'
+
+    def test_streaming_text(self):
+        """It should be possible to get text profiling data for a view which returns a StreamingHttpResponse"""
+        response = self._get_streaming_page('profile=time')
+        self.assertContains(response, 'Ordered by: internal time')
+
+    def _get_streaming_page(self, params=''):
+        url = reverse('test_streaming')
+        if params:
+            url += '?' + params
+        return self.client.get(url)
+
     def _get_test_page(self, params=''):
         url = reverse('test')
         if params:


### PR DESCRIPTION
Don't choke when profiling views that return a StreamingHttpResponse.  Still doesn't profile the actual stream data generation as it's not clear how to do that without adding some wrapper code that would always appear in the profiling results, but this at least allows profiling up through the return of the response object.

Also updated a couple of test dependencies and enabled branch coverage reporting.