### PR TITLE
Always search parameter in request.GET

### DIFF
--- a/yet_another_django_profiler/middleware.py
+++ b/yet_another_django_profiler/middleware.py
@@ -37,13 +37,8 @@ def func_strip_path(func_name):
 
 
 def in_request(request, parameter):
-    """Determine if the request contains the specified parameter, whether it's
-    a GET or a POST."""
-    if request.method == 'GET':
-        return parameter in request.GET
-    if request.method == 'POST':
-        return parameter in request.POST
-    return False
+    """Determine if the request contains the specified parameter."""
+    return parameter in request.GET
 
 
 def set_content(response, content):
@@ -148,12 +143,8 @@ class ProfilerMiddleware(object):
         self.profile_parameter = None
         if settings.YADP_ENABLED and in_request(request, settings.YADP_PROFILE_PARAMETER):
             self.error = None
-            if request.method == 'GET':
-                self.parameters = request.GET.copy()
-                request.GET = self.parameters
-            elif request.method == 'POST':
-                self.parameters = request.POST.copy()
-                request.POST = self.parameters
+            self.parameters = request.GET.copy()
+            request.GET = self.parameters
             self.fraction_parameter = self.get_parameter(settings.YADP_FRACTION_PARAMETER)
             self.max_calls_parameter = self.get_parameter(settings.YADP_MAX_CALLS_PARAMETER)
             self.pattern_parameter = self.get_parameter(settings.YADP_PATTERN_PARAMETER)


### PR DESCRIPTION
Current implementation search for "profile" parameter either in GET or in POST data, depending on request method.

I don't known if this is intentional as README only show example with "?profile" parameter added to GET data.

This PR change where yet-another-django-profile search for its parameter to only use GET data.

In my use case, it's mandatory to always use GET data, because:

* I'm profiling API, which do other request method like PATCH and PUT
* This API use application/json as POST/PATCH/PUT data, therefor adding "profile" parameter to POST is not possible.