### PR TITLE
Django 1.10 support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,8 @@
+[report]
+show_missing = true
+
 [run]
 branch = true
+source = yet_another_django_profiler
 omit =
     */tests/*

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ ve
 .idea
 .project
 .pydevproject
+.python-version
 .ropeproject
 .settings
 .coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,35 +9,29 @@ addons:
       - python3.5
 python: 2.7
 env:
-  - TOX_ENV=py27-django15
-  - TOX_ENV=py27-django16
   - TOX_ENV=py27-django17
   - TOX_ENV=py27-django18
   - TOX_ENV=py27-django19
-  - TOX_ENV=py33-django15
-  - TOX_ENV=py33-django16
+  - TOX_ENV=py27-django110
   - TOX_ENV=py33-django17
   - TOX_ENV=py33-django18
-  - TOX_ENV=py34-django15
-  - TOX_ENV=py34-django16
   - TOX_ENV=py34-django17
   - TOX_ENV=py34-django18
   - TOX_ENV=py34-django19
+  - TOX_ENV=py34-django110
   - TOX_ENV=py35-django18
   - TOX_ENV=py35-django19
-  - TOX_ENV=pypy-django15
-  - TOX_ENV=pypy-django16
+  - TOX_ENV=py35-django110
   - TOX_ENV=pypy-django17
   - TOX_ENV=pypy-django18
   - TOX_ENV=pypy-django19
-  - TOX_ENV=pypy3-django15
-  - TOX_ENV=pypy3-django16
+  - TOX_ENV=pypy-django110
   - TOX_ENV=pypy3-django17
   - TOX_ENV=pypy3-django18
   - TOX_ENV=docs
   - TOX_ENV=analyze
 install:
-  - pip install tox==2.1.1
+  - pip install -r requirements/tox.txt
   - pip install coveralls==1.1
 script:
   - tox -e $TOX_ENV

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,6 @@ env:
   - TOX_ENV=pypy-django18
   - TOX_ENV=pypy-django19
   - TOX_ENV=pypy-django110
-  - TOX_ENV=pypy3-django17
-  - TOX_ENV=pypy3-django18
   - TOX_ENV=docs
   - TOX_ENV=analyze
 install:

--- a/README.rst
+++ b/README.rst
@@ -47,11 +47,11 @@ First, get the code via pip install::
     pip install yet-another-django-profiler
 
 Then add ``yet_another_django_profiler.middleware.ProfilerMiddleware`` to your
-``MIDDLEWARE_CLASSES`` Django setting (typically at the end of the list, if
-you want to include profiling data on the other middleware that's in use).
-If you want to generate call graphs with the middleware, you also need to
-install `Graphviz <http://www.graphviz.org/Download.php>`_.  If you want to
-use the "profile" management command, you'll also need to add
+``MIDDLEWARE`` or ``MIDDLEWARE_CLASSES`` Django setting (typically at the end
+of the list, if you want to include profiling data on the other middleware
+that's in use).  If you want to generate call graphs with the middleware, you
+also need to install `Graphviz <http://www.graphviz.org/Download.php>`_.  If
+you want to use the "profile" management command, you'll also need to add
 ``yet_another_django_profiler`` to the ``INSTALLED_APPS`` setting.
 
 Middleware Usage
@@ -113,16 +113,18 @@ yet-another-django-profiler includes a ``profile`` management command which can
 be used to profile other Django management commands::
 
 
-    usage: manage.py profile [-h] [--version] [-v {0,1,2,3}] [--settings SETTINGS]
-                             [--pythonpath PYTHONPATH] [--traceback] [--no-color]
-                             [-o PATH] [-s SORT] [-f FRACTION] [-m MAX_CALLS]
-                             [-p PATTERN] [-b BACKEND] [-c CLOCK]
-                             [args [args ...]]
+    usage: manage.py profile [-h] [--version] [-v {0,1,2,3}]
+                             [--settings SETTINGS] [--pythonpath PYTHONPATH]
+                             [--traceback] [--no-color] [-o PATH] [-s SORT]
+                             [-f FRACTION] [-m MAX_CALLS] [-p PATTERN]
+                             [-b BACKEND] [-c CLOCK]
+                             other_command ...
 
     Profile another Django management command
 
     positional arguments:
-      args
+      other_command         The management command to be profiled
+      command_arguments     Arguments of the management command being profiled
 
     optional arguments:
       -h, --help            show this help message and exit
@@ -157,8 +159,6 @@ be used to profile other Django management commands::
                             Profiler backend to use (cProfile or yappi)
       -c CLOCK, --clock CLOCK
                             Yappi clock type to use (cpu or wall)
-
-
 
 Sample usage:
 

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -1,7 +1,7 @@
 yet-another-django-profiler Changelog
 =====================================
 
-1.1.0 (2016-12-12)
+1.1.0 (2017-01-10)
 ------------------
 * Added support for Django 1.10 (including the new ``MIDDLEWARE`` setting)
 * Dropped support for Django 1.5 and 1.6

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -1,6 +1,14 @@
 yet-another-django-profiler Changelog
 =====================================
 
+1.1.0 (2016-12-12)
+------------------
+* Added support for Django 1.10 (including the new ``MIDDLEWARE`` setting)
+* Dropped support for Django 1.5 and 1.6
+* Fixed profiling of management commands with arguments in Django 1.8+
+* Redirect stderr of the profiled command to be the same as the ``profile``
+  command's stderr
+
 1.0.3 (2016-02-08)
 ------------------
 * Fixed profiling of Django admin pages (by removing profiling parameters

--- a/git-hooks/install-hooks
+++ b/git-hooks/install-hooks
@@ -25,5 +25,6 @@ def install_hooks():
             else:
                 print('Created %s git hook.' % hook_name)
 
+
 if __name__ == '__main__':
     install_hooks()

--- a/git-hooks/post-merge
+++ b/git-hooks/post-merge
@@ -16,6 +16,7 @@ def popen(cmd):
     args = shlex.split(cmd)
     return subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True).stdout
 
+
 diff = popen('git diff --name-only HEAD@{1} HEAD')
 changed_files = {filename.strip() for filename in diff}
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,0 @@
-[pytest]
-DJANGO_SETTINGS_MODULE=test_settings
-addopts = --cov yet_another_django_profiler
-norecursedirs = .* docs requirements ve

--- a/requirements/analyze.txt
+++ b/requirements/analyze.txt
@@ -3,10 +3,10 @@
 # Indirect dependencies first, exact versions for consistency
 
 # flake8
-mccabe==0.4.0
-pep8==1.7.0
-pyflakes==1.0.0
+mccabe==0.5.2
+pycodestyle==2.2.0
+pyflakes==1.3.0
 
 # And now the direct dependencies
 
-flake8==2.5.2
+flake8==3.2.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,19 +1,19 @@
 # Core dependencies
 
 # Python packaging utilities
-setuptools==19.7
-pip==8.0.2
+setuptools==30.2.0
+pip==9.0.1
 
 # Indirect dependencies first, exact versions for consistency
 
 # mock
-funcsigs==0.4; python_version < '3.3'
-pbr==1.8.1; python_version < '3.3'
+funcsigs==1.0.2; python_version < '3.3'
+pbr==1.10.0; python_version < '3.3'
 
 # And now the direct dependencies
 
 # The framework we're profiling
-Django==1.9.2
+Django==1.10.4
 
 # Used to override pstats function path stripping behavior
-mock==1.3.0; python_version < '3.3'
+mock==2.0.0; python_version < '3.3'

--- a/requirements/documentation.txt
+++ b/requirements/documentation.txt
@@ -9,14 +9,14 @@ six==1.10.0
 html5lib==0.9999999
 
 # readme_renderer
-bleach==1.4.2
+bleach==1.5.0
 
 # readme_renderer, Sphinx
 docutils==0.12
-Pygments==2.1
+Pygments==2.1.3
 
 # Sphinx -> Babel
-pytz==2015.7
+pytz==2016.7
 
 # sbo-sphinx -> recommonmark
 CommonMark==0.5.4
@@ -28,16 +28,16 @@ MarkupSafe==0.23
 PyStemmer==1.3.0
 
 # sbo-sphinx-> Sphinx
-Babel==2.2.0
+Babel==2.3.4
 Jinja2==2.8
 snowballstemmer==1.2.1
 
 # sbo-sphinx
 recommonmark==0.4.0
-Sphinx==1.3.5
+Sphinx==1.5
 
 # Sphinx themes (circular dependencies of Sphinx)
-alabaster==0.7.7
+alabaster==0.7.9
 sphinx_rtd_theme==0.1.9
 
 # Direct dependencies
@@ -49,4 +49,4 @@ readme_renderer==0.7.0
 sbo-sphinx==2.2.0
 
 # Optional dependency, must be present for docs to build cleanly
-yappi==0.94; platform_python_implementation == 'CPython' and (python_version == '2.7' or python_version > '3.2')
+yappi==0.98; platform_python_implementation == 'CPython' and python_version < '3.5'

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -35,14 +35,10 @@ win_unicode_console==0.5; sys_platform == 'win32' and platform_python_implementa
 # ipdb
 ipython==5.1.0; platform_python_implementation != 'PyPy'
 
-# pytest-cov -> cov-core
-coverage==4.2
-
-# pytest-cov -> pytest, detox -> tox
+# detox -> tox
 py==1.4.31
 
-# pytest-cov
-cov-core==1.15.0
+# pytest-django, pytest-xdist
 pytest==3.0.5
 
 # pytest-xdist
@@ -57,7 +53,7 @@ ipdb==0.10.1; platform_python_implementation != 'PyPy'
 pytest-catchlog==1.2.2
 
 # For code coverage statistics generation
-pytest-cov==2.4.0
+coverage==4.3.1
 
 # Django integration for test runner
 pytest-django==3.1.2

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -2,33 +2,48 @@
 
 # Indirect dependencies first, exact versions for consistency
 
+# ipdb -> ipython -> pexpect
+ptyprocess==0.5.1; sys_platform != 'win32' and platform_python_implementation != 'PyPy'
+
 # ipdb -> ipython -> pickleshare
-path.py==8.1.2; platform_python_implementation != 'PyPy'
+path.py==9.0; platform_python_implementation != 'PyPy'
+
+# ipdb -> ipython -> prompt_toolkit, ipdb -> ipython -> traitlets
+six==1.10.0; platform_python_implementation != 'PyPy'
+
+# ipdb -> ipython -> prompt_toolkit
+wcwidth==0.1.7; platform_python_implementation != 'PyPy'
 
 # ipdb -> ipython -> traitlets
-decorator==4.0.6; platform_python_implementation != 'PyPy'
-ipython-genutils==0.1.0; platform_python_implementation != 'PyPy'
+decorator==4.0.10; platform_python_implementation != 'PyPy'
+enum34==1.1.6; platform_python_implementation != 'PyPy' and python_version == '2.7'
+ipython_genutils==0.1.0; platform_python_implementation != 'PyPy'
 
 # ipdb -> ipython
 appnope==0.1.0; sys_platform == 'darwin' and platform_python_implementation != 'PyPy'
-gnureadline==6.3.3; sys_platform == 'darwin' and platform_python_implementation != 'PyPy'
-pexpect==3.3; sys_platform != 'win32' and platform_python_implementation != 'PyPy'
-pickleshare==0.6; platform_python_implementation != 'PyPy'
+backports.shutil_get_terminal_size==1.0.0; platform_python_implementation != 'PyPy' and python_version == '2.7'
+colorama==0.3.7; sys_platform == 'win32' and platform_python_implementation != 'PyPy'
+pathlib2==2.1.0; platform_python_implementation != 'PyPy' and (python_version == '2.7' or python_version == '3.3')
+pexpect==4.2.1; sys_platform != 'win32' and platform_python_implementation != 'PyPy'
+pickleshare==0.7.4; platform_python_implementation != 'PyPy'
+prompt_toolkit==1.0.9; platform_python_implementation != 'PyPy'
+Pygments==2.1.3; platform_python_implementation != 'PyPy'
 simplegeneric==0.8.1; platform_python_implementation != 'PyPy'
-traitlets==4.1.0; platform_python_implementation != 'PyPy'
+traitlets==4.3.1; platform_python_implementation != 'PyPy'
+win_unicode_console==0.5; sys_platform == 'win32' and platform_python_implementation != 'PyPy' and python_version < '3.6'
 
 # ipdb
-ipython==4.0.3; platform_python_implementation != 'PyPy'
+ipython==5.1.0; platform_python_implementation != 'PyPy'
 
 # pytest-cov -> cov-core
-coverage==4.0.3
+coverage==4.2
 
 # pytest-cov -> pytest, detox -> tox
 py==1.4.31
 
 # pytest-cov
 cov-core==1.15.0
-pytest==2.8.7
+pytest==3.0.5
 
 # pytest-xdist
 execnet==1.4.1
@@ -36,19 +51,19 @@ execnet==1.4.1
 # And now the direct dependencies
 
 # For better debugging
-ipdb==0.8.1; platform_python_implementation != 'PyPy'
+ipdb==0.10.1; platform_python_implementation != 'PyPy'
 
 # Show log output for test failures
 pytest-catchlog==1.2.2
 
 # For code coverage statistics generation
-pytest-cov==2.2.1
+pytest-cov==2.4.0
 
 # Django integration for test runner
-pytest-django==2.9.1
+pytest-django==3.1.2
 
 # Parallel test execution support
-pytest-xdist==1.14
+pytest-xdist==1.15.0
 
 # For testing the Yappi profiler backend
-yappi==0.94; platform_python_implementation == 'CPython' and (python_version == '2.7' or (python_version > '3.2' and python_version < '3.5'))
+yappi==0.98; platform_python_implementation == 'CPython' and python_version < '3.5'

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -4,16 +4,16 @@
 # Indirect dependencies first, exact versions for consistency
 
 # detox -> eventlet
-greenlet==0.4.9
+greenlet==0.4.10
 
 # detox -> tox
-pluggy==0.3.1
+pluggy==0.4.0
 py==1.4.31
-virtualenv==14.0.5
+virtualenv==15.1.0
 
 # detox
-eventlet==0.18.1
-tox==2.3.1
+eventlet==0.19.0
+tox==2.5.0
 
 # And now the direct dependencies
 

--- a/requirements/uninstall.txt
+++ b/requirements/uninstall.txt
@@ -1,4 +1,5 @@
 # Packages which were once dependencies, but should now be removed if present.
 
+gnureadline
 nose
 pytest-capturelog

--- a/setup.py
+++ b/setup.py
@@ -34,11 +34,10 @@ setup(
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
-        'Framework :: Django :: 1.5',
-        'Framework :: Django :: 1.6',
         'Framework :: Django :: 1.7',
         'Framework :: Django :: 1.8',
         'Framework :: Django :: 1.9',
+        'Framework :: Django :: 1.10',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)',
         'Natural Language :: English',

--- a/test_settings.py
+++ b/test_settings.py
@@ -16,12 +16,13 @@ https://docs.djangoproject.com/en/1.6/ref/settings/
 
 import os
 from uuid import uuid4
+
+import django
+
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
 SECRET_KEY = str(uuid4())
 DEBUG = True
-TEMPLATE_DEBUG = False
-
 
 # Application definition
 
@@ -35,23 +36,37 @@ INSTALLED_APPS = (
     'yet_another_django_profiler',
 )
 
-MIDDLEWARE_CLASSES = (
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'yet_another_django_profiler.middleware.ProfilerMiddleware',
-)
+if django.VERSION[0] == 1 and django.VERSION[1] < 10:
+    MIDDLEWARE_CLASSES = (
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'django.middleware.common.CommonMiddleware',
+        'django.middleware.csrf.CsrfViewMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+        'django.contrib.messages.middleware.MessageMiddleware',
+        'django.middleware.clickjacking.XFrameOptionsMiddleware',
+        'yet_another_django_profiler.middleware.ProfilerMiddleware',
+    )
+else:
+    MIDDLEWARE = (
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'django.middleware.common.CommonMiddleware',
+        'django.middleware.csrf.CsrfViewMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+        'django.contrib.messages.middleware.MessageMiddleware',
+        'django.middleware.clickjacking.XFrameOptionsMiddleware',
+        'yet_another_django_profiler.middleware.ProfilerMiddleware',
+    )
 
 ROOT_URLCONF = 'test_urls'
 
-TEMPLATE_CONTEXT_PROCESSORS = (
-    'django.contrib.auth.context_processors.auth',
-    'django.core.context_processors.i18n',
-    'django.contrib.messages.context_processors.messages',
-)
+if django.VERSION[0] == 1 and django.VERSION[1] < 8:
+    TEMPLATE_DEBUG = False
+
+    TEMPLATE_CONTEXT_PROCESSORS = (
+        'django.contrib.auth.context_processors.auth',
+        'django.core.context_processors.i18n',
+        'django.contrib.messages.context_processors.messages',
+    )
 
 TEMPLATES = [
     {
@@ -61,7 +76,8 @@ TEMPLATES = [
             'context_processors': [
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
-            ]
+            ],
+            'debug': False,
         }
     },
 ]

--- a/test_urls.py
+++ b/test_urls.py
@@ -26,6 +26,7 @@ class StreamingView(View):
     def get(self, request, *args, **kwargs):
         return StreamingHttpResponse(('Line {}\n'.format(i + 1) for i in range(100)))
 
+
 if django.VERSION[0] == 1 and django.VERSION[1] < 7:
     admin.autodiscover()
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 envlist = py{27,33,34,py,py3}-django{17,18},py{27,34,py}-django{19,110},py35-django{18,19,110}
 
 [pytest]
-addopts = --cov yet_another_django_profiler --cov-report term-missing
 DJANGO_SETTINGS_MODULE=test_settings
 norecursedirs = .* build docs requirements ve
 
@@ -19,13 +18,14 @@ commands =
     {toxinidir}/requirements/clean_up_requirements.py
     pip install --quiet --requirement requirements/tests.txt
     python setup.py --quiet develop --always-unzip
-    py.test --fail-on-template-vars {posargs:yet_another_django_profiler}
+    coverage run -m pytest --fail-on-template-vars {posargs:yet_another_django_profiler}
+    coverage report
 
 [testenv:audit]
 deps = -r{toxinidir}/requirements/base.txt
 commands =
     pip --trusted-host pypi.safaribooks.com --disable-pip-version-check install --allow-all-external --find-links http://pypi.safaribooks.com/packages/ --allow-unverified audit-python-package --upgrade --quiet audit-python-package readme
-    py.test --pyargs audit_python_package -k "not test_changelog_reminder and not test_environment_markers and not test_prevent_pypi_upload and not test_testenv_installs_core_dependencies"
+    pytest --pyargs audit_python_package -k "not test_changelog_reminder and not test_environment_markers and not test_prevent_pypi_upload and not test_testenv_installs_core_dependencies"
     python setup.py check --restructuredtext --strict --metadata
 
 [testenv:docs]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,33,34,py,py3}-django{15,16,17,18},py{27,34,py}-django19,py35-django{18,19}
+envlist = py{27,33,34,py,py3}-django{17,18},py{27,34,py}-django{19,110},py35-django{18,19,110}
 
 [pytest]
 addopts = --cov yet_another_django_profiler --cov-report term-missing
@@ -8,19 +8,18 @@ norecursedirs = .* build docs requirements ve
 
 [testenv]
 deps =
-    django15: Django==1.5.12
-    django16: Django==1.6.11
     django17: Django==1.7.11
-    django18: Django==1.8.9
-    django19: Django==1.9.2
-    py{27,32,py}: funcsigs==0.4
-    py{27,32,py}: pbr==1.8.1
-    py{27,32,py}: mock==1.3.0
+    django18: Django==1.8.17
+    django19: Django==1.9.12
+    django110: Django==1.10.4
+    py{27,py}: funcsigs==1.0.2
+    py{27,py}: pbr==1.10.0
+    py{27,py}: mock==2.00
 commands =
     {toxinidir}/requirements/clean_up_requirements.py
     pip install --quiet --requirement requirements/tests.txt
     python setup.py --quiet develop --always-unzip
-    py.test --fail-on-template-vars {posargs}
+    py.test --fail-on-template-vars {posargs:yet_another_django_profiler}
 
 [testenv:audit]
 deps = -r{toxinidir}/requirements/base.txt

--- a/yet_another_django_profiler/__init__.py
+++ b/yet_another_django_profiler/__init__.py
@@ -12,4 +12,4 @@ the ones that came before it.  Originally described at
 http://blog.safariflow.com/2013/11/21/profiling-django-via-middleware/
 """
 
-__version__ = (1, 0, 3)  # Update docs/CHANGELOG.rst if you increment the version
+__version__ = (1, 1, 0)  # Update docs/CHANGELOG.rst if you increment the version

--- a/yet_another_django_profiler/conf.py
+++ b/yet_another_django_profiler/conf.py
@@ -104,4 +104,5 @@ class LazySettings(object):
         mod = import_module(mod_name)
         return getattr(mod, function_name)
 
+
 settings = LazySettings()

--- a/yet_another_django_profiler/middleware.py
+++ b/yet_another_django_profiler/middleware.py
@@ -117,10 +117,11 @@ class ProfilerMiddleware(object):
     * https://bitbucket.org/brodie/geordi
     """
 
-    def __init__(self):
+    def __init__(self, get_response=None):
         if not settings.YADP_ENABLED:
             # Disable the middleware completely when YADP_ENABLED = False
             raise MiddlewareNotUsed()
+        self.get_response = get_response
         self.error = None
         self.profiler = None
         self.get_parameters = None
@@ -130,6 +131,10 @@ class ProfilerMiddleware(object):
         self.max_calls_parameter = None
         self.pattern_parameter = None
         self.profile_parameter = None
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        return self.process_response(request, response)
 
     def get_parameter(self, name):
         """Get the specified parameter from the request, whether it's a GET or a

--- a/yet_another_django_profiler/tests/__init__.py
+++ b/yet_another_django_profiler/tests/__init__.py
@@ -1,9 +1,0 @@
-# encoding: utf-8
-# Created by Jeremy Bowman on Fri Feb 21 12:15:29 EST 2014
-# Copyright (c) 2014, 2015 Safari Books Online. All rights reserved.
-#
-# This software may be modified and distributed under the terms
-# of the 3-clause BSD license.  See the LICENSE file for details.
-"""
-Tests for Yet Another Django Profiler
-"""

--- a/yet_another_django_profiler/tests/test_parameters.py
+++ b/yet_another_django_profiler/tests/test_parameters.py
@@ -144,7 +144,8 @@ class CProfileTest(TestCase, ParameterCases):
         assert settings.YADP_PROFILER_BACKEND == 'cProfile'
 
 
-@pytest.mark.skipif(platform.python_implementation() != 'CPython' or sys.version_info[:2] in ((3, 2), (3, 5)),
+@pytest.mark.skipif(platform.python_implementation() != 'CPython' or
+                    (sys.version_info[0] == 3 and sys.version_info[1] > 4),
                     reason='yappi does not yet work in this Python implementation')
 @override_settings(YADP_ENABLED=True, YADP_PROFILER_BACKEND='yappi')
 class YappiTest(TestCase, ParameterCases):


### PR DESCRIPTION
* Added support for Django 1.10 (including the new `MIDDLEWARE` setting)
* Dropped support for Django 1.5 and 1.6 (no longer supported by pytest-django)
* Fixed profiling of management commands with arguments in Django 1.8+
* Redirect stderr of the profiled command to be the same as the `profile` command's stderr

I'd like to start using pip-tools to manage the dependencies so I don't need to keep manually updating the version numbers, but it looks like I'll need to submit a patch for [environment marker support](https://github.com/nvie/pip-tools/issues/206) first.