### PR TITLE
Force pip version until requirements can be updated

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ deps =
     py{27,py}: pbr==1.10.0
     py{27,py}: mock==2.00
 commands =
+    pip install pip==9.0.1
     {toxinidir}/requirements/clean_up_requirements.py
     pip install --quiet --requirement requirements/tests.txt
     python setup.py --quiet develop --always-unzip


### PR DESCRIPTION
`clean_up_requirements.py` is not currently compatible with pip 10.0.1. This forces us to stay on pip 9 until `clean_up_requirements.py` can be fixed.