### PR TITLE
Always return a 200 status_code

### DIFF
--- a/yet_another_django_profiler/middleware.py
+++ b/yet_another_django_profiler/middleware.py
@@ -181,6 +181,7 @@ class ProfilerMiddleware(object):
 
     def process_response(self, request, response):
         if self.profile_parameter is not None:
+            response.status_code = 200
             if self.error:
                 return text_response(response, self.error)
             self.profiler.create_stats()


### PR DESCRIPTION
This makes it easier to profile form submissions, where the response may otherwise include a 302 redirect.