### PR TITLE
Fix Content-Length truncating the profile response

### DIFF
--- a/yet_another_django_profiler/middleware.py
+++ b/yet_another_django_profiler/middleware.py
@@ -44,6 +44,7 @@ def in_request(request, parameter):
 
 def set_content(response, content):
     """Set the content of the provided response, whether or not it's streaming"""
+    del response['Content-length']  # Make sure the response is not truncated
     if response.streaming:
         # No point in consuming the previous iterator, the profiler has
         # already stopped


### PR DESCRIPTION
The PDF and text outputs are truncated when a `Content-Length` header is still set.
This happens for example when returning data from DRF's Response class.